### PR TITLE
cmake configure_file: Write to binary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ build
 __pycache__
 
 # CMake - configured files
+include/sensitive_detector/NEventAction.hh
 include/sensitive_detector/AnalysisManager.hh
 src/physics/Physics.cc

--- a/include/sensitive_detector/NEventAction.hh.in
+++ b/include/sensitive_detector/NEventAction.hh.in
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#define NEVENTACTION_UPDATE_FREQUENCY @UPDATE_FREQUENCY@
+
 #include "G4Event.hh"
 #include "G4UserEventAction.hh"
 #include "globals.hh"

--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -27,10 +27,10 @@ else()
     set(HADRON_ELASTIC "G4HadronElasticPhysicsHP" CACHE STRING "Use G4HadronElasticPhysicsHP.")
     set(HADRON_INELASTIC "G4HadronPhysicsShielding" CACHE STRING "Use G4HadronPhysicsShielding")
 endif()
-configure_file(${PROJECT_SOURCE_DIR}/src/physics/Physics.cc.in ${PROJECT_SOURCE_DIR}/src/physics/Physics.cc)
+configure_file(${PROJECT_SOURCE_DIR}/src/physics/Physics.cc.in ${PROJECT_BINARY_DIR}/src/physics/Physics.cc)
 
 find_package(Geant4 REQUIRED)
 link_libraries(${Geant4_LIBRARIES})
 
-add_library(physics Physics.cc)
+add_library(physics ${PROJECT_BINARY_DIR}/src/physics/Physics.cc)
 target_compile_options(physics PUBLIC -Wall -Wextra)

--- a/src/sensitive_detector/CMakeLists.txt
+++ b/src/sensitive_detector/CMakeLists.txt
@@ -16,11 +16,12 @@
 #    Copyright (C) 2020 Udo Friman-Gayer
 
 include_directories(${PROJECT_SOURCE_DIR}/include/sensitive_detector)
+include_directories(${PROJECT_BINARY_DIR}/include/sensitive_detector)
 
 find_package(Geant4 REQUIRED)
 link_libraries(${Geant4_LIBRARIES})
 
-configure_file(${PROJECT_SOURCE_DIR}/include/sensitive_detector/AnalysisManager.hh.in ${PROJECT_SOURCE_DIR}/include/sensitive_detector/AnalysisManager.hh)
+configure_file(${PROJECT_SOURCE_DIR}/include/sensitive_detector/AnalysisManager.hh.in ${PROJECT_BINARY_DIR}/include/sensitive_detector/AnalysisManager.hh)
 add_library(analysisManager AnalysisManager.cc)
 target_compile_options(analysisManager PUBLIC -Wall -Wextra)
 
@@ -30,7 +31,7 @@ target_compile_options(nDetectorHit PUBLIC -Wall -Wextra)
 add_library(nRunAction NRunAction.cc)
 target_compile_options(nRunAction PUBLIC -Wall -Wextra)
 
-configure_file(${PROJECT_SOURCE_DIR}/src/sensitive_detector/NEventAction.cc.in ${PROJECT_SOURCE_DIR}/src/sensitive_detector/NEventAction.cc)
+configure_file(${PROJECT_SOURCE_DIR}/include/sensitive_detector/NEventAction.hh.in ${PROJECT_BINARY_DIR}/include/sensitive_detector/NEventAction.hh)
 add_library(nEventAction NEventAction.cc)
 target_link_libraries(nEventAction nRunAction)
 target_compile_options(nEventAction PUBLIC -Wall -Wextra)

--- a/src/sensitive_detector/NEventAction.cc
+++ b/src/sensitive_detector/NEventAction.cc
@@ -40,7 +40,7 @@ using std::setw;
 #include "NRunAction.hh"
 
 NEventAction::NEventAction(AnalysisManager* ana_man)
-: G4UserEventAction(), analysis_manager(ana_man), update_frequency(@UPDATE_FREQUENCY@)
+: G4UserEventAction(), analysis_manager(ana_man), update_frequency(NEVENTACTION_UPDATE_FREQUENCY)
 {}
 
 void NEventAction::BeginOfEventAction(const G4Event* event){

--- a/src/sensitive_detector/event/CMakeLists.txt
+++ b/src/sensitive_detector/event/CMakeLists.txt
@@ -31,6 +31,7 @@ target_compile_options(SensitiveDetector PUBLIC -Wall -Wextra)
 
 add_library(tupleManager TupleManager.cc)
 target_include_directories(tupleManager PUBLIC ${PROJECT_SOURCE_DIR}/include/geometry ${PROJECT_SOURCE_DIR}/include/geometry/${GEOMETRY_DIR})
+target_include_directories(DetectorHit PUBLIC ${PROJECT_BINARY_DIR}/include/sensitive_detector)
 target_link_libraries(tupleManager analysisManager DetectorHit)
 target_compile_options(tupleManager PUBLIC -Wall -Wextra)
 


### PR DESCRIPTION
Files created by cmake configure_file should be placed in the binary
directory, not the source directory. The .gitignore was modified to
still allow for in-source builds.