### PR TITLE
Don’t assume ownership of Geant4-owned raw pointers in utr-owned shared_ptrs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,13 @@ set(SENSITIVE_DETECTOR_DIR
       STRING
       "Select directory in `${PROJECT_SOURCE_DIR}/src/sensitive_detector` that contains the desired sensitive detector. Possible choices: `edep`, `event` (default), `flux`, `tracker`."
 )
+set_property(
+  CACHE SENSITIVE_DETECTOR_DIR
+    PROPERTY STRINGS
+             "edep"
+             "event"
+             "flux"
+             "tracker")
 
 add_compile_options(-Wall -Wextra -Wpedantic)
 

--- a/include/sensitive_detector/AnalysisManager.hh
+++ b/include/sensitive_detector/AnalysisManager.hh
@@ -23,10 +23,6 @@
 
 #pragma once
 
-#include <memory>
-
-using std::shared_ptr;
-
 #include <string>
 #include <vector>
 
@@ -46,10 +42,10 @@ public:
   void Book(string output_file_name);
   [[maybe_unused]] virtual void
   CreateNtupleColumns(G4AnalysisManager *analysisManager);
-  void FillNtuple(const G4Event *event, vector<shared_ptr<G4VHit>> &hits);
+  void FillNtuple(const G4Event *event, vector<G4VHit *> hits);
   [[maybe_unused]] virtual size_t
   FillNtupleColumns(G4AnalysisManager *analysisManager, const G4Event *event,
-                    vector<shared_ptr<G4VHit>> &hits);
+                    vector<G4VHit *> hits);
   void Save();
 
 protected:

--- a/include/sensitive_detector/edep/TupleManager.hh
+++ b/include/sensitive_detector/edep/TupleManager.hh
@@ -27,6 +27,7 @@ public:
 
   void CreateNtupleColumns(G4AnalysisManager *analysisManager) override;
 
-  size_t FillNtupleColumns(G4AnalysisManager *analysisManager, const G4Event *event,
-                         vector<shared_ptr<G4VHit>> &hits) override;
+  size_t FillNtupleColumns(G4AnalysisManager *analysisManager,
+                           const G4Event *event,
+                           vector<G4VHit *> hits) override;
 };

--- a/include/sensitive_detector/event/TupleManager.hh
+++ b/include/sensitive_detector/event/TupleManager.hh
@@ -29,7 +29,7 @@ public:
 
   size_t FillNtupleColumns(G4AnalysisManager *analysisManager,
                            const G4Event *event,
-                           vector<shared_ptr<G4VHit>> &hits) override;
+                           vector<G4VHit *> hits) override;
 
 private:
   size_t n_sensitive_detectors;

--- a/include/sensitive_detector/flux/TupleManager.hh
+++ b/include/sensitive_detector/flux/TupleManager.hh
@@ -27,6 +27,7 @@ public:
 
   void CreateNtupleColumns(G4AnalysisManager *analysisManager) override;
 
-  void FillNtupleColumns(G4AnalysisManager *analysisManager, G4Event *event,
-                         vector<shared_ptr<G4VHit>> hits) override;
+  size_t FillNtupleColumns(G4AnalysisManager *analysisManager,
+                           const G4Event *event,
+                           vector<G4VHit *> hits) override;
 };

--- a/include/sensitive_detector/tracker/TupleManager.hh
+++ b/include/sensitive_detector/tracker/TupleManager.hh
@@ -27,6 +27,7 @@ public:
 
   void CreateNtupleColumns(G4AnalysisManager *analysisManager) override;
 
-  void FillNtupleColumns(G4AnalysisManager *analysisManager, G4Event *event,
-                         vector<shared_ptr<G4VHit>> hits) override;
+  size_t FillNtupleColumns(G4AnalysisManager *analysisManager,
+                           const G4Event *event,
+                           vector<G4VHit *> hits) override;
 };

--- a/src/sensitive_detector/AnalysisManager.cc
+++ b/src/sensitive_detector/AnalysisManager.cc
@@ -67,17 +67,17 @@ void AnalysisManager::CreateNtupleColumns(G4AnalysisManager *analysisManager) {
   }
 }
 
-void AnalysisManager::FillNtuple(const G4Event *event,
-                                 vector<shared_ptr<G4VHit>> &hits) {
+void AnalysisManager::FillNtuple(const G4Event *event, vector<G4VHit *> hits) {
 
   G4AnalysisManager *analysisManager = G4AnalysisManager::Instance();
   FillNtupleColumns(analysisManager, event, hits);
   analysisManager->AddNtupleRow(0);
 }
 
-size_t AnalysisManager::FillNtupleColumns(
-    G4AnalysisManager *analysisManager, const G4Event *event,
-    [[maybe_unused]] vector<shared_ptr<G4VHit>> &hits) {
+size_t
+AnalysisManager::FillNtupleColumns(G4AnalysisManager *analysisManager,
+                                   const G4Event *event,
+                                   [[maybe_unused]] vector<G4VHit *> hits) {
 
   size_t col = 0;
   analysisManager->FillNtupleIColumn(0, col++, event->GetEventID());

--- a/src/sensitive_detector/edep/EventAction.cc
+++ b/src/sensitive_detector/edep/EventAction.cc
@@ -19,8 +19,8 @@
 
 #include <memory>
 
-using std::make_shared;
-using std::shared_ptr;
+using std::make_unique;
+using std::unique_ptr;
 
 #include "G4Event.hh"
 #include "G4EventManager.hh"
@@ -33,7 +33,7 @@ EventAction::EventAction(AnalysisManager *ana_man) : NEventAction(ana_man) {}
 
 void EventAction::EndOfEventAction(const G4Event *event) {
   G4VHitsCollection *hc = nullptr;
-  shared_ptr<DetectorHit> cumulative_hit;
+  unique_ptr<DetectorHit> cumulative_hit;
 
   for (int n_hc = 0; n_hc < event->GetHCofThisEvent()->GetNumberOfCollections();
        ++n_hc) {
@@ -45,11 +45,13 @@ void EventAction::EndOfEventAction(const G4Event *event) {
       for (size_t i = 0; i < hc->GetSize(); ++i)
         edep += ((DetectorHit *)hc->GetHit(i))->GetEdep();
 
-      cumulative_hit = make_shared<DetectorHit>();
+      cumulative_hit = make_unique<DetectorHit>();
       cumulative_hit->SetDetectorID(
           ((DetectorHit *)hc->GetHit(0))->GetDetectorID());
       cumulative_hit->SetEdep(edep);
-      vector<shared_ptr<G4VHit>> hits{cumulative_hit}; // Wrap cumulative hit into a vector for compatibility with the AnalysisManager API.
+      vector<G4VHit *> hits{
+          cumulative_hit.get()}; // Wrap cumulative hit into a vector for
+                                 // compatibility with the AnalysisManager API.
       analysis_manager->FillNtuple(event, hits);
     }
   }

--- a/src/sensitive_detector/edep/TupleManager.cc
+++ b/src/sensitive_detector/edep/TupleManager.cc
@@ -32,13 +32,13 @@ void TupleManager::CreateNtupleColumns(G4AnalysisManager *analysisManager) {
 
 size_t TupleManager::FillNtupleColumns(G4AnalysisManager *analysisManager,
                                        [[maybe_unused]] const G4Event *event,
-                                       vector<shared_ptr<G4VHit>> &hits) {
+                                       vector<G4VHit *> hits) {
 
   auto col = AnalysisManager::FillNtupleColumns(analysisManager, event, hits);
 
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetDetectorID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetDetectorID());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetEdep());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetEdep());
   return col;
 }

--- a/src/sensitive_detector/event/TupleManager.cc
+++ b/src/sensitive_detector/event/TupleManager.cc
@@ -44,13 +44,13 @@ void TupleManager::CreateNtupleColumns(G4AnalysisManager *analysisManager) {
 
 size_t TupleManager::FillNtupleColumns(G4AnalysisManager *analysisManager,
                                        const G4Event *event,
-                                       vector<shared_ptr<G4VHit>> &hits) {
+                                       vector<G4VHit *> hits) {
 
   auto col = AnalysisManager::FillNtupleColumns(analysisManager, event, hits);
 
   for (size_t i = 0; i < hits.size(); ++i) {
     analysisManager->FillNtupleDColumn(
-        0, col++, dynamic_pointer_cast<DetectorHit>(hits[i])->GetEdep());
+        0, col++, static_cast<DetectorHit *>(hits[i])->GetEdep());
   }
   // The number of entries in std::vector hits will only be as large as highest
   // ID of all detectors that were hit. There may be detectors with an even

--- a/src/sensitive_detector/flux/EventAction.cc
+++ b/src/sensitive_detector/flux/EventAction.cc
@@ -33,20 +33,20 @@ EventAction::EventAction(AnalysisManager *ana_man) : NEventAction(ana_man) {}
 void EventAction::EndOfEventAction(const G4Event *event) {
   G4VHitsCollection *hc = nullptr;
   int particleID{0}, trackID{0};
-  shared_ptr<DetectorHit> hit;
+  DetectorHit *hit;
 
   for (int n_hc = 0; n_hc < event->GetHCofThisEvent()->GetNumberOfCollections();
        ++n_hc) {
     hc = event->GetHCofThisEvent()->GetHC(n_hc);
 
     if (hc->GetSize() > 0) {
-      hit = make_shared<DetectorHit>((DetectorHit *)hc->GetHit(0));
+      hit = (DetectorHit *)hc->GetHit(0);
       analysis_manager->FillNtuple(event, {hit});
       particleID = hit->GetParticleID();
       trackID = hit->GetTrackID();
 
       for (size_t i = 1; i < hc->GetSize(); ++i) {
-        hit = make_shared<DetectorHit>((DetectorHit *)hc->GetHit(i));
+        hit = (DetectorHit *)hc->GetHit(i);
         if (hit->GetParticleID() != particleID ||
             hit->GetTrackID() != trackID) {
           analysis_manager->FillNtuple(event, {hit});

--- a/src/sensitive_detector/flux/TupleManager.cc
+++ b/src/sensitive_detector/flux/TupleManager.cc
@@ -38,32 +38,32 @@ void TupleManager::CreateNtupleColumns(G4AnalysisManager *analysisManager) {
 
 size_t TupleManager::FillNtupleColumns(G4AnalysisManager *analysisManager,
                                        [[maybe_unused]] const G4Event *event,
-                                       vector<shared_ptr<G4VHit>> &hits) {
+                                       vector<G4VHit *> hits) {
 
   auto col = AnalysisManager::FillNtupleColumns(analysisManager, event, hits);
 
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetDetectorID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetDetectorID());
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetParticleID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetParticleID());
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetParentID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetParentID());
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetTrackID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetTrackID());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetEkin());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetEkin());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetPos().x());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetPos().x());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetPos().y());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetPos().y());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetPos().z());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetPos().z());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetMom().x());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetMom().x());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetMom().y());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetMom().y());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetMom().z());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetMom().z());
 
   return col;
 }

--- a/src/sensitive_detector/tracker/EventAction.cc
+++ b/src/sensitive_detector/tracker/EventAction.cc
@@ -37,7 +37,6 @@ void EventAction::EndOfEventAction(const G4Event *event) {
     hc = event->GetHCofThisEvent()->GetHC(n_hc);
 
     for (size_t i = 0; i < hc->GetSize(); ++i)
-      analysis_manager->FillNtuple(
-          event, {make_shared<DetectorHit>((DetectorHit *)hc->GetHit(i))});
+      analysis_manager->FillNtuple(event, {(DetectorHit *)hc->GetHit(i)});
   }
 }

--- a/src/sensitive_detector/tracker/TupleManager.cc
+++ b/src/sensitive_detector/tracker/TupleManager.cc
@@ -39,32 +39,32 @@ void TupleManager::CreateNtupleColumns(G4AnalysisManager *analysisManager) {
 
 size_t TupleManager::FillNtupleColumns(G4AnalysisManager *analysisManager,
                                        const G4Event *event,
-                                       vector<shared_ptr<G4VHit>> &hits) {
+                                       vector<G4VHit *> hits) {
   auto col = AnalysisManager::FillNtupleColumns(analysisManager, event, hits);
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetTrackID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetTrackID());
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetParticleID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetParticleID());
   analysisManager->FillNtupleIColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetDetectorID());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetDetectorID());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetGlobalTime());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetGlobalTime());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetEdep());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetEdep());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetEkin());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetEkin());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetPos().x());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetPos().x());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetPos().y());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetPos().y());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetPos().z());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetPos().z());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetMom().x());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetMom().x());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetMom().y());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetMom().y());
   analysisManager->FillNtupleDColumn(
-      0, col++, dynamic_pointer_cast<DetectorHit>(hits[0])->GetMom().z());
+      0, col++, static_cast<DetectorHit *>(hits[0])->GetMom().z());
 
   return col;
 }


### PR DESCRIPTION
Since 08ef9099764f9c77a30eccbf7339ec6269f3ed64, `shared_ptr` is used in all sensitive detectors to encapsulate raw pointers returned by Geant4.

The usage of smart pointers is a noble endveavour worthy of support, however, the internals of Geant4 make it difficult to persue this paradigm, because it relies on its own internal memory management and only exposes raw pointers without any ownership information externally. Trying to shoehorn these raw pointers into shared points is a recipe for desaster, because as soon as the owning object goes out of scope, the underlying raw pointer is deleted, with Geant4 being unaware of this change. This inevitably results in attempting to access a null pointer or potentially even double-freeing it.

The hit vector in the `TupleManager` is especially weird, because it is used both by objects created by us but also by Geant4. Since we cannot change Geant4, we have to build or own interfaces and similarly pass raw pointers. But at least we can manage the ownership of the objects we create using smart pointers, only requireing an additional copy to (safely) pass the raw pointer along to the internal interface. 
